### PR TITLE
Fix for the undefined variable error

### DIFF
--- a/plugin/VimCompletesMe.vim
+++ b/plugin/VimCompletesMe.vim
@@ -61,7 +61,7 @@ function! s:vim_completes_me(shift_tab)
   endif
 
   " First fallback to keyword completion if special completion was already tried.
-  if b:completion_tried
+  if exists('b:completion_tried') && b:completion_tried
     let b:completion_tried = 0
     return "\<C-e>" . dirs[!dir]
   endif


### PR DESCRIPTION
When completion is initialises for the very first time, `b:completion_tried` variable doesn't appear to be defined. This results in the following error message:

`E121 Undefined variable: b:completion_tried`

This commit fixes that error by checking if the `b:completion_tried` variable is defined or not, before looking at its value.