### PR TITLE
Update VimCompletesMe.txt

### DIFF
--- a/doc/VimCompletesMe.txt
+++ b/doc/VimCompletesMe.txt
@@ -39,7 +39,7 @@ intelligently (depending on the context) use:
 
 1. Local keyword completion (|i_Ctrl-X_Ctrl-N|)
 2. File path completion     (|i_Ctrl-X_Ctrl-F|)
-3. Omni completion          (|i_Ctrl-X_Ctrl-F|)
+3. Omni completion          (|i_Ctrl-X_Ctrl-O|)
 
 You can set |b:vcm_tab_complete| to one of the following to use a specific type
 of completion:


### PR DESCRIPTION
The option for Omni-completion was wrongly written as |i_Ctrl-X_Ctrl-F|. Corrected it to |i_Ctrl-X_Ctrl-O|.