### PR TITLE
Added Omnicomplete support for '::'

### DIFF
--- a/plugin/VimCompletesMe.vim
+++ b/plugin/VimCompletesMe.vim
@@ -47,12 +47,13 @@ function! s:vim_completes_me(shift_tab)
   " operator
   let period = match(substr, '\.') != -1
   let arrow_oper = match(substr, '->') != -1
+  let double_colon = match(substr, '::') != -1
   let file_path = (has('win32') || has('win64')) ? '\\' : '\/'
   let file_pattern = match(substr, file_path) != -1
 
   if file_pattern
     return "\<C-x>\<C-f>"
-  elseif (period || arrow_oper) && (&omnifunc != '')
+  elseif (period || arrow_oper || double_colon) && (&omnifunc != '')
     if get(b:, 'tab_complete_pos', []) == pos
       let exp = "\<C-x>" . dirs[!dir]
     else


### PR DESCRIPTION
The contextual tab feature in VimCompletesMe uses '->' and '.' to decide for <C-x><C-o>, which is ok for most languages.
Another common pattern is '::' used for example in C++ or Rust.