### PR TITLE
respect 'complete' opt

### DIFF
--- a/plugin/VimCompletesMe.vim
+++ b/plugin/VimCompletesMe.vim
@@ -82,7 +82,7 @@ function! s:vim_completes_me(shift_tab)
   elseif map ==? "vim"
     return "\<C-x>\<C-v>"
   else
-    return "\<C-x>" . dirs[!dir]
+    return dirs[!dir]
   endif
 endfunction
 


### PR DESCRIPTION
Thus, no need for `let b:vcm ... = dict`, but Vim already provides for `set complete+=k`.

Off topic: Better make the omni-completion patterns customizable!

Great plugin!