### PR TITLE
make order and context of insert mode completion methods customizable

### DIFF
--- a/doc/VimCompletesMe.txt
+++ b/doc/VimCompletesMe.txt
@@ -13,115 +13,87 @@ Help on using VimCompletesMe                                   *VimCompletesMe*
 ==============================================================================
  1. INTRODUCTION                                         *VimCompletesMe-intro*
 
-VimCompletesMe is a tab completion plugin for Vim with minimalism in mind.
+VimCompletesMe is a minimalistic Vim plugin that lets the user complete the currently typed text by hitting the <tab> key.
 
-It will use Vim's |ins-completion| to provide tab completion and you can
-configure VimCompletesMe to use a specific type of completions.
+It uses Vim's built-in |ins-completion| methods depending on the context.
+The completion methods, the order and the context in which they are used are
+fully customizable.
+
+If a file-path is completed to a directory name, ending in '/' (or '\' on MS Windows) then the completion can be reiterated by hitting this delimiter, that is, '\' (or '\' on MS Windows).
 
 ==============================================================================
 2. CONFIGURATION                                 *VimCompletesMe-configuration*
 
-The following aspects of VimCompletesMe's behavior are configurable using the
-following options:
+The following variables :
 
-|'b:vcm_tab_complete'|          Use a specific type of completion.
-|'g:vcm_direction'|             Controls the direction of the completion.
-|'g:vcm_s_tab_behavior'|        Controls the behavior of Shift-Tab.
-|'g:vcm_default_maps'|          Set up default maps (Tab + Shift Tab)
-|'b:vcm_omni_pattern|           Local pattern to trigger Omni-completion
-|'g:vcm_omni_pattern|           Global pattern to trigger Omni-completion
+|'g:vim_completions'|           global dictionary of completion methods.
+|'b:vcm_completions'|           buffer-local dictionary of completion methods.
 
 ------------------------------------------------------------------------------
-                                                         *'b:vcm_tab_complete'*
-Values: string                                                                ~
-Default: ''                                                                   ~
+                                                         *'g:vcm_completions'*
 
-Controls the type of completion to use. If empty, the |<Tab>| key will
-intelligently (depending on the context) use:
+Configures the order and context in which one of the following completion methods is used after the |<tab>| key is hit:
 
-1. Local keyword completion (|i_Ctrl-X_Ctrl-N|)
-2. File path completion     (|i_Ctrl-X_Ctrl-F|)
-3. Omni completion          (|i_Ctrl-X_Ctrl-O|)
+1. File Path   completion                     (|i_Ctrl-X_Ctrl-F|)
+2. Omni        completion                     (|i_Ctrl-X_Ctrl-O|)
+3. User        completion                     (|i_Ctrl-X_Ctrl-O|)
+4. Line        completion                     (|i_Ctrl-X_Ctrl-O|)
+5. Vim         completion                     (|i_Ctrl-X_Ctrl-O|)
+6. Spell Check completion                     (|i_Ctrl-X_Ctrl-O|)
+7. Generic     completion                     (|i_Ctrl-N|)
 
-You can set |b:vcm_tab_complete| to one of the following to use a specific type
-of completion:
-
-1. "user"   - User-defined completion |i_Ctrl-X_Ctrl-U|
-2. "vim"    - Vim command line completion |i_Ctrl-X_Ctrl-V|
-3. "omni"   - Omni completion |i_Ctrl-X_Ctrl-O|
-
-The b:vcm_tab_complete makes a great |:autocmd| as follows:
+and which defaults to
 >
-    autocmd FileType ruby let b:vcm_tab_complete = "tags"
+let g:vcm_completions = {
+  \ 'file':  {'rank': 10,
+  \           'keys': "\<C-x>\<C-f>",
+  \           'pattern': '\v' . (has('win32') ? '\f\\' : '\/') . '\f*$' },
+  \ 'omni':  {'rank': 20,
+  \           'keys': "\<C-x>\<C-o>",
+  \           'pattern': '\v\k+(\.|->|::)\k*$' },
+  \ 'user':  {'rank': 30,
+  \           'keys': "\<C-x>\<C-u>",
+  \           'pattern': 0 },
+  \ 'line':  {'rank': 40,
+  \           'keys': "\<C-x>\<C-l>",
+  \           'pattern': '\v^\s*\k+$' },
+  \ 'spell': {'rank': 50,
+  \           'keys': "\<C-x>\<C-s>",
+  \           'pattern': 0 },
+  \ 'vim':   {'rank': 60,
+  \           'keys': "\<C-x>\<C-v>",
+  \           'pattern': 0 },
+  \ 'gen':   {'rank': 99,
+  \           'keys': "\<C-n>",
+  \           'pattern': '\v\k+$' },
+  \ }
+<
+where, for each completion method ('file', 'omni', ...),
+
+      - 'rank' defines the order in which the completion methods are tried,
+      the lower the earlier,
+      - 'pattern' defines the regular expression that must match the text from
+      the start of the current line up to the cursor (and which never matches
+      if set to 0), and
+      - 'keys' defines the keys that must be hit to complete by the method.
+
+When none of the special completions above get any results,
+you can press Tab again to force Vim's generic keyword completion.
+
+                                                         *'b:vcm_completions'*
+
+Configures buffer-locally the order and context in which one of the above
+completion methods is used after the |<tab>| key is hit. It is best set by a
+FileType autocmd such as:
+>
+    autocmd FileType vim
+    \ let b:vcm_completions = deepcopy(g:vcm_completions) |
+    \ b:vcm_completions.vim.rank=0
 <
 
-When none of the special completions above get any results, you can press Tab
-again to have VimCompletesMe switch the context to keyword completion. In some
-situations (like after completing something and then trying the context switch
-again without leaving insert mode), you may need a Vim version greater than
-7.3.598 to get the best context switch behavior. The context will be
-automatically switched back to the completion set in the |b:vcm_tab_complete|
-variable.
-
-NOTE: The "dict" option requires the user to set |'dictionary'| in their
-|vimrc| file. In Unix, you can put the following in your ~/.vimrc:
->
-    set dictionary=/usr/share/dict/words
-<
-NOTE: The "tags" option will use a tags file generated by |Exuberant_Ctags|
-
-------------------------------------------------------------------------------
-                                                            *'g:vcm_direction'*
-Values: string                                                                ~
-Default: 'n'                                                                  ~
-
-Controls the direction of tab completion. By default, if a popup menu is
-opened during completion, the |<Tab>| key will cycle forward through the list.
-
-You can change it to cycle backwards through the list by putting the following
-in your |vimrc|:
->
-    let g:vcm_direction = 'p'
-<
-------------------------------------------------------------------------------
-                                                       *'g:vcm_s_tab_behavior'*
-Values: numeric                                                               ~
-Default: 0                                                                    ~
-
-Controls the shift-tab behavior used by VimCompletesMe.
-
-By default, pressing |<S-Tab>| after a space, or a tab will de-indent the
-current line.
-
-If you change this option to 1, |<S-Tab>| will work just like |<Tab>|.
-
-You can change this variable by putting the following in your |vimrc|:
->
-    let g:vcm_s_tab_behavior = 1
-<
-------------------------------------------------------------------------------
-                                                         *'g:vcm_default_maps'*
-Values: numeric                                                               ~
-Default: 1                                                                    ~
-
-Set up mappings for Tab and Shift-Tab. If you would like to use your
-own mappings, unset this variable by putting the following in your |vimrc|:
->
-    let g:vcm_default_maps = 0
-<
-------------------------------------------------------------------------------
-                                                         *'g:vcm_omni_pattern*
-Values: string                                                               ~
-Default: '\v(\.\|->\|::)'                                                    ~
-
-The global pattern after which VimCompletesMe triggers Omni-completion.
-
-------------------------------------------------------------------------------
-                                                         *'b:vcm_omni_pattern*
-Values: string                                                               ~
-Default: g:vcm_omni_pattern                                                  ~
-
-The buffer-local pattern after which VimCompletesMe triggers Omni-completion.
+In some situations (like after completing something and then trying the
+context switch again without leaving insert mode), you may need a Vim
+version greater than 7.3.598 to get the best context switch behavior.
 
 ==============================================================================
  3. FREQUENTLY ASKED QUESTIONS                             *VimCompletesMe-faq*
@@ -134,29 +106,7 @@ Solution: Just make a mapping like the following, in your |vimrc|:
     inoremap <expr> <CR> pumvisible() ? "\<C-y>" : "\<C-g>u\<CR>"
 <
 
-2. When pressing the Tab key, why is the the last popup item selected?     ~
-
-This is because VimCompletesMe is invoking |i_Ctrl-P| by default for you.
-Pressing the Tab key will then cycle forwards the list, so some users are
-confused that it takes two Tab presses to jump to the first item in the list.
-
-However, this behavior is the default Vim behavior, and VimCompletesMe agrees
-with it. Invoking |i_Ctrl-P| instead of |i_Ctrl-N| is done because it is more
-likely that the keyword you are trying to complete is before the current
-cursor position. When the Tab key is pressed when the popup menu is open,
-VimCompletesMe simply uses Ctrl-N to advance to the next item in the popup
-menu. If you would like VimCompletesMe to invoke |i_Ctrl-N| instead, see the
-|'g:vcm_direction'| option.
-
-It is also useful to check out the "longest" attribute of the |'completeopt'|
-option. Setting the following in your |vimrc| will insert the longest matching
-string and then popup the completion item, so you will always start at the
-head of the popup menu list:
->
-    set completeopt+=longest
-<
-
-3. How do I make VimCompletesMe work with various snippet engines?         ~
+2. How do I make VimCompletesMe work with various snippet engines?         ~
 
 A simple solution is to ensure that the Tab and Shift-Tab keys do not conflict
 with any other plugins. Thus, you can either disable VimCompletesMe's

--- a/plugin/VimCompletesMe.vim
+++ b/plugin/VimCompletesMe.vim
@@ -1,103 +1,107 @@
-" VimCompletesMe.vim - For super simple tab completion
-" Maintainer:          Akshay Hegde <http://github.com/ajh17>
-" Version:             1.2.1
-" Website:             <http://github.com/ajh17/VimCompletesMe>
-
-" Vimscript Setup: {{{1
+" Vimscript Setup
 if exists("g:loaded_VimCompletesMe") || v:version < 703 || &compatible
   finish
 endif
 let g:loaded_VimCompletesMe = 1
 
-" Options: {{{1
-if !exists('g:vcm_s_tab_behavior')
-  let g:vcm_s_tab_behavior = 0
-endif
+let g:vcm_completions = {
+  \ 'file':  {'rank': 10,
+  \           'keys': "\<C-x>\<C-f>",
+  \           'pattern': '\v' . (has('win32') ? '\f\\' : '\/') . '\f*$' },
+  \ 'omni':  {'rank': 20,
+  \           'keys': "\<C-x>\<C-o>",
+  \           'pattern': '\v\k+(\.|->|::)\k*$' },
+  \ 'user':  {'rank': 30,
+  \           'keys': "\<C-x>\<C-u>",
+  \           'pattern': 0 },
+  \ 'line':  {'rank': 40,
+  \           'keys': "\<C-x>\<C-l>",
+  \           'pattern': '\v^\s*\k+$' },
+  \ 'spell': {'rank': 50,
+  \           'keys': "\<C-x>\<C-s>",
+  \           'pattern': 0 },
+  \ 'vim':   {'rank': 60,
+  \           'keys': "\<C-x>\<C-v>",
+  \           'pattern': 0 },
+  \ 'gen':   {'rank': 99,
+  \           'keys': "\<C-n>",
+  \           'pattern': '\v\k+$' },
+  \ }
 
-if !exists('g:vcm_direction')
-  let g:vcm_direction = 'n'
-endif
+function! s:rank(i1, i2)
+  let rank1 = b:completions[a:i1].rank
+  let rank2 = b:completions[a:i2].rank
+	return rank1 == rank2 ? 0 : rank1 > rank2 ? 1 : -1
+endfunction
 
-if !exists('g:vcm_default_maps')
-  let g:vcm_default_maps = 1
-endif
-
-if !exists('g:vcm_omni_pattern')
-  let g:vcm_omni_pattern = '\v(\.\|->\|::)'
-endif
-
-" Functions: {{{1
-function! s:vim_completes_me(shift_tab)
-  let dirs = ["\<c-p>", "\<c-n>"]
-  let dir = g:vcm_direction =~? '[nf]'
-  let map = exists('b:vcm_tab_complete') ? b:vcm_tab_complete : ''
+function! s:complete(shift)
+  let Ctrl_PN = a:shift ? "\<C-p>" : "\<C-n>"
 
   if pumvisible()
-    if a:shift_tab
-      return dirs[!dir]
-    else
-      return dirs[dir]
-    endif
+    return Ctrl_PN
   endif
-
-  " Figure out whether we should indent.
+  
+  " Cursor after whitespace => indent
   let pos = getpos('.')
-  let substr = matchstr(strpart(getline(pos[1]), 0, pos[2]-1), "[^ \t]*$")
-  if strlen(substr) == 0
-    return (a:shift_tab && !g:vcm_s_tab_behavior) ? "\<C-d>" : "\<Tab>"
+  let textBeforeCursor = strpart(getline(pos[1]), 0, pos[2]-1)
+  if textBeforeCursor =~ '\v(\s+|^)$'
+    return a:shift ? "\<C-W>" : "\<tab>"
   endif
 
-  " Figure out if user has started typing a path or a period or an arrow
-  " operator
-  let omni_pattern = match(substr, get(b:, 'vcm_omni_pattern')) != -1
-  let file_path = (has('win32') || has('win64')) ? '\\' : '\/'
-  let file_pattern = match(substr, file_path) != -1
-
-  if file_pattern
-    return "\<C-x>\<C-f>"
-  elseif omni_pattern && (&omnifunc != '')
-    if get(b:, 'tab_complete_pos', []) == pos
-      let exp = "\<C-x>" . dirs[!dir]
-    else
-      let exp = "\<C-x>\<C-o>"
-    endif
-    let b:tab_complete_pos = pos
-    return exp
-  endif
-
-  " First fallback to keyword completion if special completion was already tried.
-  if exists('b:completion_tried') && b:completion_tried
+  " Completion failed => Vim's generic keyword completion
+  if get(b:,'completion_tried') && (get(b:, 'tab_complete_pos', []) == pos)
     let b:completion_tried = 0
-    return "\<C-e>" . dirs[!dir]
+    return "\<C-e>" . Ctrl_PN
   endif
 
-  " Fallback
+  " Start completing => keep record for fallback
+  let b:tab_complete_pos = pos
   let b:completion_tried = 1
-  if map ==? "user"
-    return "\<C-x>\<C-u>"
-  elseif map ==? "omni"
-    return "\<C-x>\<C-o>"
-  elseif map ==? "vim"
-    return "\<C-x>\<C-v>"
-  else
-    return dirs[!dir]
+
+  " User is typing a path or omnicomplete or tabcomplete pattern?
+  for c in sort(keys(b:completions), 's:rank')
+    let is_pattern = ( (b:completions[c].pattern isnot 0)  && match(textBeforeCursor, b:completions[c].pattern) >= 0)
+    if is_pattern
+      return b:completions[c].keys
+    endif
+  endfor
+endfunction
+
+function! s:vcm_init()
+  if !exists('b:completions')
+    let b:completions = deepcopy(g:vcm_completions)
+  endif
+  if empty(&l:omnifunc) && exists('b:completions.omni')
+    let b:completions.omni.pattern = 0
+  elseif empty(&l:completefunc) && exists('b:completions.user')
+    let b:completions.user.pattern = 0
+  elseif !&l:spell && exists('b:completions.spell')
+    let b:completions.spell.pattern = 0
   endif
 endfunction
 
-inoremap <expr> <plug>vim_completes_me_forward  <sid>vim_completes_me(0)
-inoremap <expr> <plug>vim_completes_me_backward <sid>vim_completes_me(1)
-
-" Maps: {{{1
-if g:vcm_default_maps
-  imap <Tab>   <plug>vim_completes_me_forward
-  imap <S-Tab> <plug>vim_completes_me_backward
-endif
-
-" Autocmds {{{1
 augroup VCM
   autocmd!
+  autocmd InsertEnter * call s:vcm_init()
   autocmd InsertEnter * let b:completion_tried = 0
   if v:version > 703 || v:version == 703 && has('patch598')
     autocmd CompleteDone * let b:completion_tried = 0
   endif
 augroup END
+
+inoremap <expr> <plug>vim_completes_me_forward  <sid>complete(0)
+inoremap <expr> <plug>vim_completes_me_backward <sid>complete(1)
+
+function! <SID>cursorBehindPath()
+  let pos = getpos('.')
+  let textBeforeCursor = strpart(getline(pos[1]), 0, pos[2]-1)
+  return  textBeforeCursor =~ '\v\f+' . (has('win32') ? '\\' : '\/')
+endfunction
+
+if !(exists('g:vcm_no_default_maps') && g:vcm_no_default_maps)
+  imap              <Tab>     <plug>vim_completes_me_forward
+  imap              <S-Tab>   <plug>vim_completes_me_backward
+  execute   'inoremap <expr> ' . (has('win32') ? '\' : '/') . ' '
+        \ . '(pumvisible() && <SID>cursorBehindPath()) ?'
+        \ . '"\<C-y>\<C-x><C-f>" : "' . (has('win32') ? '\' : '/') . '"'
+endif


### PR DESCRIPTION
Well, the rewritten documentation explains what happened: The case by case adhoc check is now replaced by a for loop over all completion methods that come with 

- a rank, determining the order in which they are tried, and
- their context, the pattern which determines when they are tried at all.

This is customized, first globally by
```vim
let g:vcm_completions = {
  \ 'file':  {'rank': 10,
  \           'keys': "\<C-x>\<C-f>",
  \           'pattern': '\v' . (has('win32') ? '\f\\' : '\/') . '\f*$' },
  \ 'omni':  {'rank': 20,
  \           'keys': "\<C-x>\<C-o>",
  \           'pattern': '\v\k+(\.|->|::)\k*$' },
  \ 'user':  {'rank': 30,
  \           'keys': "\<C-x>\<C-u>",
  \           'pattern': 0 },
  \ 'line':  {'rank': 40,
  \           'keys': "\<C-x>\<C-l>",
  \           'pattern': '\v^\s*\k+$' },
  \ 'spell': {'rank': 50,
  \           'keys': "\<C-x>\<C-s>",
  \           'pattern': 0 },
  \ 'vim':   {'rank': 60,
  \           'keys': "\<C-x>\<C-v>",
  \           'pattern': 0 },
  \ 'gen':   {'rank': 99,
  \           'keys': "\<C-n>",
  \           'pattern': '\v\k+$' },
  \ }
```
and then the buffer local variant `b:vcm_completions` for each filetype.
 